### PR TITLE
ci: Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
   push:
     tags:
       - 'v*'
+
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-24.04

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,8 @@
+version: 2
+
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: >-
       {{- .ProjectName }}_
       {{- .Version }}_
@@ -11,7 +14,8 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end -}}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - README.md
       - LICENSE

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ init:
 	go install github.com/rakyll/gotest@latest
 	go install mvdan.cc/gofumpt@latest
 	go install golang.org/x/tools/cmd/goimports@latest
-	go install github.com/goreleaser/goreleaser@latest
+	go install github.com/goreleaser/goreleaser/v2@latest
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 


### PR DESCRIPTION
GitHub now requires the 'contents: write' permission for jobs that are publishing new releases. Also the goreleaser config changed with v2 and had to be updated [1].

[1]: https://goreleaser.com/deprecations/